### PR TITLE
fix: should be user?

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,12 @@
-_For new Package Requests, see the guidelines_  
+_For new Package Requests, see the guidelines_
 
 ### Setup
-_Package Name:_ 
-_Package Version:_ 
+_Package Name:_
+_Package Version:_
 
-_NAS Model:_ 
-_NAS Architecture:_ 
-_DSM version:_ 
+_NAS Model:_
+_NAS Architecture:_
+_DSM version:_
 
 ### Expected behavior
 Tell us what should happen
@@ -15,12 +15,14 @@ Tell us what should happen
 Tell us what happens instead
 
 ### Steps to reproduce
-_1._ 
-_2._ 
-_3._ 
+_1._
+_2._
+_3._
 
 #### Package log
 _Check Package Center or `/usr/local/{package}/var/`_
+
+_DSM7: `/var/log/packages/{package}.log`_
 ```
 Insert the package log here
 ```

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         # x64=x86_64, evansport=x86, aarch64=armv8, armv7, 88f6281=armv5, ppc853x/qoriq=ppc
         # https://github.com/SynoCommunity/spksrc/wiki/Synology-and-SynoCommunity-Package-Architectures
-        arch: [noarch, x64-6.1, evansport-6.1, aarch64-6.1, armv7-6.1, armv7-1.2, 88f6281-6.1, qoriq-6.1, ppc853x-5.2]
+        arch: [noarch, x64-6.1, x64-7.0, evansport-6.1, aarch64-6.1, armv7-6.1, armv7-1.2, 88f6281-6.1, qoriq-6.1, ppc853x-5.2]
 
     steps:
       - name: Cache toolchains

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -4,11 +4,11 @@
 #  Cannot remove user as still in use or may be DSM service itself
 # Require warning in ChangeLog and manual user/group cleanup
 
-if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
-    INST_LOG="${SYNOPKG_TEMP_LOGFILE}"
-else
+# if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
     INST_LOG="/tmp/${SYNOPKG_PKGNAME}_install.log"
-fi
+# else
+#     INST_LOG="${SYNOPKG_TEMP_LOGFILE}"
+# fi
 
 INST_ETC="/var/packages/${SYNOPKG_PKGNAME}/etc"
 INST_VARIABLES="${INST_ETC}/installer-variables"
@@ -95,9 +95,9 @@ syno_remove_user ()
         if synouser --get "${RM_USER}" &> /dev/null; then
             echo "Removing user ${RM_USER}" >> ${INST_LOG}
             synouser --del "${RM_USER}" >> ${INST_LOG} 2>&1
-            synouser --rebuild all
+            synouser --rebuild all >> ${INST_LOG} 2>&1
             # Also rebuild groups so users are removed
-            synogroup --rebuild all
+            synogroup --rebuild all >> ${INST_LOG} 2>&1
         fi
     fi
 }
@@ -109,9 +109,9 @@ syno_group_create ()
     if [ -n "${EFF_USER}" ]; then
         echo "Creating group ${GROUP}" >> ${INST_LOG}
         # Create syno group
-        synogroup --add "${GROUP}" "${EFF_USER}" >> ${INST_LOG}
+        synogroup --add "${GROUP}" "${EFF_USER}" >> ${INST_LOG} 2>&1
         # Set description of the syno group
-        synogroup --descset "${GROUP}" "${GROUP_DESC}" >> ${INST_LOG}
+        synogroup --descset "${GROUP}" "${GROUP_DESC}" >> ${INST_LOG} 2>&1
     fi
 }
 
@@ -125,7 +125,7 @@ syno_group_remove ()
             echo "Removing group ${RM_GROUP}" >> ${INST_LOG}
             # Remove syno group
             synogroup --del "${RM_GROUP}" >> ${INST_LOG} 2>&1
-            synogroup --rebuild all
+            synogroup --rebuild all >> ${INST_LOG} 2>&1
         fi
     fi
 }
@@ -142,7 +142,7 @@ syno_user_add_to_group ()
         MEMBERS="$(synogroup --get $ADD_GROUP | grep '^[0-9]' | sed 's/.*\[\([^]]*\)].*/\1/' | tr '\n' ' ')"
         # The "synogroup --member" command clears all users before adding new ones
         # so all the users must be listed on the command line
-        synogroup --member "$ADD_GROUP" $MEMBERS "${ADD_USER}" >> ${INST_LOG}
+        synogroup --member "$ADD_GROUP" $MEMBERS "${ADD_USER}" >> ${INST_LOG} 2>&1
     fi
 }
 
@@ -161,7 +161,7 @@ set_syno_permissions ()
         if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:rwxpdDaARWcC-:fd--\"`" ]; then
             # First Unix permissions, but only if it's in Linux mode
             if [ "`synoacltool -get \"${DIRNAME}\"| grep \"Linux mode\"`" ]; then
-                set_unix_permissions "${DIRNAME}"
+                set_unix_permissions "${DIRNAME}" >> ${INST_LOG} 2>&1
                 # If it is linux mode (due to old package) we need to add "administrators"-group,
                 # otherwise the folder is not accessible from File Station anymore!
                 synoacltool -add "${DIRNAME}" "group:administrators:allow:rwxpdDaARWc--:fd--" >> ${INST_LOG} 2>&1
@@ -221,7 +221,7 @@ syno_user_add_to_legacy_group () {
         MEMBERS=${MEMBERS//$LEGACY_USER}
         # The "synogroup --member" command clears all users before adding new ones
         # so all the users must be listed on the command line
-        synogroup --member "$LEGACY_GROUP" $MEMBERS "${NEW_USER}" >> ${INST_LOG}
+        synogroup --member "$LEGACY_GROUP" $MEMBERS "${NEW_USER}" >> ${INST_LOG} 2>&1
     fi
 }
 
@@ -298,7 +298,7 @@ postinst ()
         # Create share if does not exist
         #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
         if ! synoshare --get "${SHARE_NAME}" &> /dev/null ; then
-            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG}
+            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG} 2>&1
         fi
 
         # Add user permission if no GROUP is set in UI
@@ -306,7 +306,7 @@ postinst ()
         if [ ! -n "$GROUP" ] && [ -n "${EFF_USER}" ]; then
             synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" >> ${INST_LOG} 2>&1
         fi
-        synoshare --build
+        synoshare --build >> ${INST_LOG} 2>&1
 
         $MKDIR "${SHARE_PATH}"
 
@@ -316,12 +316,12 @@ postinst ()
         fi
     fi
 
-    $MKDIR "${INST_VAR}"
+    $MKDIR "${INST_VAR}" >> ${INST_LOG} 2>&1
 
     call_func "service_postinst"
     call_func "service_create_links"
 
-    $CP "${INST_LOG}" "${INST_VAR}"
+    $CP "${INST_LOG}" "${INST_VAR}" >> ${INST_LOG} 2>&1
     if [ -n "${LOG_FILE}" ]; then
         echo "Installation log: ${INST_VAR}/${SYNOPKG_PKGNAME}_install.log" >> ${LOG_FILE}
     fi
@@ -357,7 +357,7 @@ postuninst ()
 
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         # Remove link
-        $RM "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG}
+        $RM "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG} 2>&1
 
         # Remove syno group if empty
         syno_group_remove "${GROUP}"
@@ -370,7 +370,7 @@ postuninst ()
     call_func "service_remove_links"
 
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
-        $RM "${INST_VARIABLES}"
+        $RM "${INST_VARIABLES}" >> ${INST_LOG} 2>&1
     fi
     exit 0
 }
@@ -381,14 +381,14 @@ preupgrade ()
     call_func "service_preupgrade"
 
     # Save some stuff
-    $RM "$TMP_DIR" >> ${INST_LOG}
-    $MKDIR "$TMP_DIR" >> ${INST_LOG}
+    $RM "$TMP_DIR" >> ${INST_LOG} 2>&1
+    $MKDIR "$TMP_DIR" >> ${INST_LOG} 2>&1
 
     call_func "service_save"
 
     # Beware of /. outside the quotes
     # Needed to copy all files including hidden ones
-    $CP "${INST_VAR}"/. "$TMP_DIR" >> ${INST_LOG}
+    $CP "${INST_VAR}"/. "$TMP_DIR" >> ${INST_LOG} 2>&1
     exit 0
 }
 
@@ -399,12 +399,12 @@ postupgrade ()
     call_func "service_restore"
 
     # Restore some stuff, has to be cp otherwise fails on directories
-    $CP "${TMP_DIR}"/. "${INST_VAR}" >> ${INST_LOG}
+    $CP "${TMP_DIR}"/. "${INST_VAR}" >> ${INST_LOG} 2>&1
 
     # Correct permissions of var folder
     set_unix_permissions "${INST_VAR}"
 
-    $RM "$TMP_DIR" >> ${INST_LOG}
+    $RM "$TMP_DIR" >> ${INST_LOG} 2>&1
 
     call_func "service_postupgrade"
 

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -4,10 +4,16 @@
 #  Cannot remove user as still in use or may be DSM service itself
 # Require warning in ChangeLog and manual user/group cleanup
 
-INST_LOG="/tmp/${SYNOPKG_PKGNAME}_install.log"
+if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
+    INST_LOG="${SYNOPKG_TEMP_LOGFILE}"
+else
+    INST_LOG="/tmp/${SYNOPKG_PKGNAME}_install.log"
+fi
+
 INST_ETC="/var/packages/${SYNOPKG_PKGNAME}/etc"
 INST_VARIABLES="${INST_ETC}/installer-variables"
 INST_VAR="${SYNOPKG_PKGDEST}/var"
+# INST_VAR="${SYNOPKG_PKGVAR}"
 
 # Optional FWPORTS file
 FWPORTS_FILE="/var/packages/${SYNOPKG_PKGNAME}/conf/${SYNOPKG_PKGNAME}.sc"
@@ -243,9 +249,10 @@ postinst ()
     log_step "postinst"
     save_wizard_variables
 
-    # Link for backward compatibility of binaries location
-    $LN "${SYNOPKG_PKGDEST}" "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG}
-
+    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
+        # Link for backward compatibility of binaries location
+        $LN "${SYNOPKG_PKGDEST}" "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG}
+    fi
     # Add firewall config
     if [ -r "${FWPORTS_FILE}" ]; then
         echo "Installing service configuration ${FWPORTS_FILE}" >> ${INST_LOG}

--- a/mk/spksrc.service.installer
+++ b/mk/spksrc.service.installer
@@ -298,7 +298,7 @@ postinst ()
         # Create share if does not exist
         #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
         if ! synoshare --get "${SHARE_NAME}" &> /dev/null ; then
-            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG} 2>&1
+            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "$USER" "" 1 0 >> ${INST_LOG} 2>&1
         fi
 
         # Add user permission if no GROUP is set in UI

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -1,8 +1,9 @@
 #!/bin/sh
 
-# DSM 5 -> 6 upgrade path:
-#  Cannot remove user as still in use or may be DSM service itself
-# Require warning in ChangeLog and manual user/group cleanup
+# DSM 5 -> 7 upgrade path:
+# Not supported
+# DSM 6 -> 7 upgrade path:
+# Not supported (yet)
 
 # if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
     INST_LOG="/tmp/${SYNOPKG_PKGNAME}_install.log"
@@ -84,125 +85,39 @@ save_wizard_variables ()
 # Remove user from system and from groups it is member of
 syno_remove_user ()
 {
-    RM_USER=$1
-    if [ -n "${RM_USER}" ]; then
-        # Check if user exists
-        if synouser --get "${RM_USER}" &> /dev/null; then
-            echo "Removing user ${RM_USER}" >> ${INST_LOG}
-            synouser --del "${RM_USER}" >> ${INST_LOG} 2>&1
-            synouser --rebuild all >> ${INST_LOG} 2>&1
-            # Also rebuild groups so users are removed
-            synogroup --rebuild all >> ${INST_LOG} 2>&1
-        fi
-    fi
+    return 0
 }
 
 # Create syno group $GROUP with parameter user as member
 syno_group_create ()
 {
-    EFF_USER=$1
-    if [ -n "${EFF_USER}" ]; then
-        echo "Creating group ${GROUP}" >> ${INST_LOG}
-        # Create syno group
-        synogroup --add "${GROUP}" "${EFF_USER}" >> ${INST_LOG} 2>&1
-        # Set description of the syno group
-        synogroup --descset "${GROUP}" "${GROUP_DESC}" >> ${INST_LOG} 2>&1
-    fi
+    return 0
 }
 
 # Delete syno group if empty
 syno_group_remove ()
 {
-    RM_GROUP=$1
-    if [ -n "${RM_GROUP}" ]; then
-        # Check if syno group is empty
-        if ! synogroup --get "${RM_GROUP}" | grep -q "0:\["; then
-            echo "Removing group ${RM_GROUP}" >> ${INST_LOG}
-            # Remove syno group
-            synogroup --del "${RM_GROUP}" >> ${INST_LOG} 2>&1
-            synogroup --rebuild all >> ${INST_LOG} 2>&1
-        fi
-    fi
+    return 0
 }
 
 # Add user to existing group
 syno_user_add_to_group ()
 {
-    ADD_USER=$1
-    ADD_GROUP=$2
-    # Check user already in group
-    if ! synogroup --get "$ADD_GROUP" | grep "^[0-9]:\[${ADD_USER}\]" &> /dev/null; then
-        # Add user, not in group yet
-        echo "Adding '${ADD_USER}' to '${ADD_GROUP}'" >> ${INST_LOG}
-        MEMBERS="$(synogroup --get $ADD_GROUP | grep '^[0-9]' | sed 's/.*\[\([^]]*\)].*/\1/' | tr '\n' ' ')"
-        # The "synogroup --member" command clears all users before adding new ones
-        # so all the users must be listed on the command line
-        synogroup --member "$ADD_GROUP" $MEMBERS "${ADD_USER}" >> ${INST_LOG} 2>&1
-    fi
+    return 0
 }
 
 # Sets recursive permissions for ${GROUP} on specified directory
 # Usage: set_syno_permissions "${SHARE_FOLDER}" "${GROUP}"
 set_syno_permissions ()
 {
-    DIRNAME=`realpath "${1}"`
-    GROUP="${2}"
-
-    VOLUME=$(echo "${DIRNAME}" | awk -F/ '{print "/"$2}')
-
-    # Ensure directory resides in /volumeX before setting GROUP permissions
-    if [ "`echo ${VOLUME} | cut -c2-7`" = "volume" ]; then
-        # Set read/write permissions for GROUP for folder and subfolders
-        if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:rwxpdDaARWcC-:fd--\"`" ]; then
-            # First Unix permissions, but only if it's in Linux mode
-            if [ "`synoacltool -get \"${DIRNAME}\"| grep \"Linux mode\"`" ]; then
-                # If it is linux mode (due to old package) we need to add "administrators"-group,
-                # otherwise the folder is not accessible from File Station anymore!
-                synoacltool -add "${DIRNAME}" "group:administrators:allow:rwxpdDaARWc--:fd--" >> ${INST_LOG} 2>&1
-            fi
-
-            # Then fix the Synology permissions
-            echo "Granting '${GROUP}' group permissions on ${DIRNAME}" >> ${INST_LOG}
-            synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:rwxpdDaARWcC-:fd--" >> ${INST_LOG} 2>&1
-            find "${DIRNAME}" -type d -exec synoacltool -enforce-inherit "{}" \; >> ${INST_LOG} 2>&1
-        fi
-
-        # Walk up the tree and set traverse execute permissions for GROUP up to VOLUME
-        while [ "${DIRNAME}" != "${VOLUME}" ]; do
-            if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:r.x\"`" ]; then
-                # Here we also need to make sure the admin can access data via File Station
-                if [ "`synoacltool -get \"${DIRNAME}\"| grep \"Linux mode\"`" ]; then
-                    synoacltool -add "${DIRNAME}" "group:administrators:allow:rwxpdDaARWc--:fd--" >> ${INST_LOG} 2>&1
-                fi
-                # Add the new group permissions
-                echo "Granting '${GROUP}' group basic permissions on ${DIRNAME}" >> ${INST_LOG}
-                synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:r-x---a-R----:---n" >> ${INST_LOG} 2>&1
-            fi
-            DIRNAME="$(dirname "${DIRNAME}")"
-        done
-    else
-        echo "Skip granting '${GROUP}' group permissions on ${DIRNAME} as the directory does not reside in '/volumeX'. Set manually if needed." >> ${INST_LOG}
-    fi
+    return 0
 }
 
 # If package was moved to new group, we need to add the new package user
 # also to the old group. Only if the legacy user was in the old group.
 # Usage: syno_user_add_to_legacy_group "${NEW_USER}" "${LEGACY_USER}" "${LEGACY_GROUP}"
 syno_user_add_to_legacy_group () {
-    NEW_USER=$1
-    LEGACY_USER=$2
-    LEGACY_GROUP=$3
-
-    # Check if user in old group
-    if synogroup --get "$LEGACY_GROUP" | grep "^[0-9]:\[${LEGACY_USER}\]" &> /dev/null; then
-        # Add new user and remove old one
-        echo "Adding '${NEW_USER}' to '${LEGACY_GROUP}' for backwards compatibility" >> ${INST_LOG}
-        MEMBERS="$(synogroup --get $LEGACY_GROUP | grep '^[0-9]' | sed 's/.*\[\([^]]*\)].*/\1/' | tr '\n' ' ')"
-        MEMBERS=${MEMBERS//$LEGACY_USER}
-        # The "synogroup --member" command clears all users before adding new ones
-        # so all the users must be listed on the command line
-        synogroup --member "$LEGACY_GROUP" $MEMBERS "${NEW_USER}" >> ${INST_LOG} 2>&1
-    fi
+    return 0
 }
 
 
@@ -229,72 +144,29 @@ postinst ()
     log_step "postinst"
     save_wizard_variables
 
-    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
-        # Link for backward compatibility of binaries location
-        $LN "${SYNOPKG_PKGDEST}" "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG}
-    fi
-    # Add firewall config
-    if [ -r "${FWPORTS_FILE}" ]; then
-        echo "Installing service configuration ${FWPORTS_FILE}" >> ${INST_LOG}
-        servicetool --install-configure-file --package "${FWPORTS_FILE}" >> ${INST_LOG} 2>&1
-    fi
-
-    # Service user management
-    # if [ -n "${EFF_USER}" ]; then
-    #     if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
-    #         # DSM 5 specific operations
-    #         # Create prefixed synouser
-    #         if ! cat /etc/passwd | grep "${EFF_USER}:x:" &> /dev/null; then
-    #             synouser --add "${EFF_USER}" "" "$USER_DESC" 0 "" 0 >> ${INST_LOG} 2>&1
-    #             # Set HOME for consistency with DSM 6, location available even if homes not enabled
-    #             BACKUP_PASSWD="/tmp/install_${SYNOPKG_PKGNAME}_passwd"
-    #             cp /etc/passwd ${BACKUP_PASSWD}
-    #             sed -i "s#/var/services/homes/${EFF_USER}#/var/packages/${SYNOPKG_PKGNAME}/target#" /etc/passwd
-    #         fi
+    # # Share management
+    # if [ -n "${SHARE_PATH}" ]; then
+    #     echo "Configuring ${SHARE_PATH}" >> ${INST_LOG}
+    #     # Create share if does not exist
+    #     #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
+    #     if ! synoshare --get "${SHARE_NAME}" &> /dev/null ; then
+    #         synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG} 2>&1
     #     fi
-    #     # Register service in "users" group to access any content
-    #     if [ "$ADD_USER_IN_USERS" = "yes" ]; then
-    #         syno_user_add_to_group "${EFF_USER}" "users"
+
+    #     # Add user permission if no GROUP is set in UI
+    #     # GROUP permission will be added in set_syno_permissions
+    #     if [ ! -n "$GROUP" ] && [ -n "${EFF_USER}" ]; then
+    #         synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" >> ${INST_LOG} 2>&1
+    #     fi
+    #     synoshare --build >> ${INST_LOG} 2>&1
+
+    #     $MKDIR "${SHARE_PATH}"
+
+    #     # Permissions for folder, up to volume
+    #     if [ -n "$GROUP" ]; then
+    #         set_syno_permissions "${SHARE_PATH}" "${GROUP}"
     #     fi
     # fi
-
-    # # Only if a group is provided via UI or set by script
-    # if [ -n "$GROUP" ]; then
-    #     # Check if group already exists
-    #     if ! synogroup --get "$GROUP" &> /dev/null; then
-    #         # Group does not exist yet: create with user as member
-    #         syno_group_create "${EFF_USER}"
-    #     fi
-    #     if synogroup --get "$GROUP" &> /dev/null; then
-    #         syno_user_add_to_group "${EFF_USER}" "${GROUP}"
-    #     fi
-    #     # Not sure but invoked with hope DSM is updated
-    #     synogroup --rebuild all
-    # fi
-
-    # Share management
-    if [ -n "${SHARE_PATH}" ]; then
-        echo "Configuring ${SHARE_PATH}" >> ${INST_LOG}
-        # Create share if does not exist
-        #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
-        if ! synoshare --get "${SHARE_NAME}" &> /dev/null ; then
-            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG} 2>&1
-        fi
-
-        # Add user permission if no GROUP is set in UI
-        # GROUP permission will be added in set_syno_permissions
-        if [ ! -n "$GROUP" ] && [ -n "${EFF_USER}" ]; then
-            synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" >> ${INST_LOG} 2>&1
-        fi
-        synoshare --build >> ${INST_LOG} 2>&1
-
-        $MKDIR "${SHARE_PATH}"
-
-        # Permissions for folder, up to volume
-        if [ -n "$GROUP" ]; then
-            set_syno_permissions "${SHARE_PATH}" "${GROUP}"
-        fi
-    fi
 
     $MKDIR "${INST_VAR}" >> ${INST_LOG} 2>&1
 
@@ -311,15 +183,6 @@ postinst ()
 preuninst ()
 {
     log_step "preuninst"
-
-    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
-        # Remove firewall config
-        if [ -r "${FWPORTS_FILE}" ]; then
-            echo "Removing service configuration ${SYNOPKG_PKGNAME}.sc" >> ${INST_LOG}
-            servicetool --remove-configure-file --package "${SYNOPKG_PKGNAME}.sc" >> ${INST_LOG} 2>&1
-        fi
-    fi
-
     call_func "service_preuninst"
     exit 0
 }
@@ -331,12 +194,6 @@ postuninst ()
     if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
         # Remove link
         $RM "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG} 2>&1
-
-        # Remove syno group if empty
-        syno_group_remove "${GROUP}"
-
-        # Remove user
-        syno_remove_user "${EFF_USER}"
     fi
 
     call_func "service_postuninst"

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -5,12 +5,12 @@
 # DSM 6 -> 7 upgrade path:
 # Not supported (yet)
 
-INST_LOG="${SYNOPKG_TEMP_LOGFILE}"
+
+INST_LOG="${SYNOPKG_PKGVAR}/${SYNOPKG_PKGNAME}_install.log"
 
 INST_ETC="/var/packages/${SYNOPKG_PKGNAME}/etc"
 INST_VARIABLES="${INST_ETC}/installer-variables"
-INST_VAR="${SYNOPKG_PKGDEST}/var"
-# INST_VAR="${SYNOPKG_PKGVAR}"
+INST_VAR="${SYNOPKG_PKGVAR}"
 
 # Optional FWPORTS file
 FWPORTS_FILE="/var/packages/${SYNOPKG_PKGNAME}/conf/${SYNOPKG_PKGNAME}.sc"

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -5,11 +5,7 @@
 # DSM 6 -> 7 upgrade path:
 # Not supported (yet)
 
-# if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
-    INST_LOG="/tmp/${SYNOPKG_PKGNAME}_install.log"
-# else
-#     INST_LOG="${SYNOPKG_TEMP_LOGFILE}"
-# fi
+INST_LOG="${SYNOPKG_TEMP_LOGFILE}"
 
 INST_ETC="/var/packages/${SYNOPKG_PKGNAME}/etc"
 INST_VARIABLES="${INST_ETC}/installer-variables"
@@ -19,12 +15,7 @@ INST_VAR="${SYNOPKG_PKGDEST}/var"
 # Optional FWPORTS file
 FWPORTS_FILE="/var/packages/${SYNOPKG_PKGNAME}/conf/${SYNOPKG_PKGNAME}.sc"
 
-# Versions lower then DSM 6 don't support an upgrade folder
-if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
-    TMP_DIR="/var/tmp/${SYNOPKG_PKGNAME}/var"
-else
-    TMP_DIR="${SYNOPKG_TEMP_UPGRADE_FOLDER}/var"
-fi
+TMP_DIR="${SYNOPKG_TEMP_UPGRADE_FOLDER}/var"
 
 # Source package specific variable and functions
 SVC_SETUP=`dirname $0`"/service-setup"
@@ -82,45 +73,36 @@ save_wizard_variables ()
     fi
 }
 
-# Remove user from system and from groups it is member of
 syno_remove_user ()
 {
     echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_remove_user() is no longer supported."
     return 0
 }
 
-# Create syno group $GROUP with parameter user as member
 syno_group_create ()
 {
     echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_group_create() is no longer supported."
     return 0
 }
 
-# Delete syno group if empty
 syno_group_remove ()
 {
     echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_group_remove() is no longer supported."
     return 0
 }
 
-# Add user to existing group
 syno_user_add_to_group ()
 {
     echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_user_add_to_group() is no longer supported."
     return 0
 }
 
-# Sets recursive permissions for ${GROUP} on specified directory
-# Usage: set_syno_permissions "${SHARE_FOLDER}" "${GROUP}"
 set_syno_permissions ()
 {
     echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: set_syno_permissions() is no longer supported."
     return 0
 }
 
-# If package was moved to new group, we need to add the new package user
-# also to the old group. Only if the legacy user was in the old group.
-# Usage: syno_user_add_to_legacy_group "${NEW_USER}" "${LEGACY_USER}" "${LEGACY_GROUP}"
 syno_user_add_to_legacy_group () {
     echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_user_add_to_legacy_group() is no longer supported."
     return 0
@@ -149,30 +131,6 @@ postinst ()
 {
     log_step "postinst"
     save_wizard_variables
-
-    # # Share management
-    # if [ -n "${SHARE_PATH}" ]; then
-    #     echo "Configuring ${SHARE_PATH}" >> ${INST_LOG}
-    #     # Create share if does not exist
-    #     #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
-    #     if ! synoshare --get "${SHARE_NAME}" &> /dev/null ; then
-    #         synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG} 2>&1
-    #     fi
-
-    #     # Add user permission if no GROUP is set in UI
-    #     # GROUP permission will be added in set_syno_permissions
-    #     if [ ! -n "$GROUP" ] && [ -n "${EFF_USER}" ]; then
-    #         synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" >> ${INST_LOG} 2>&1
-    #     fi
-    #     synoshare --build >> ${INST_LOG} 2>&1
-
-    #     $MKDIR "${SHARE_PATH}"
-
-    #     # Permissions for folder, up to volume
-    #     if [ -n "$GROUP" ]; then
-    #         set_syno_permissions "${SHARE_PATH}" "${GROUP}"
-    #     fi
-    # fi
 
     $MKDIR "${INST_VAR}" >> ${INST_LOG} 2>&1
 

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -1,0 +1,384 @@
+#!/bin/sh
+
+# DSM 5 -> 6 upgrade path:
+#  Cannot remove user as still in use or may be DSM service itself
+# Require warning in ChangeLog and manual user/group cleanup
+
+# if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
+    INST_LOG="/tmp/${SYNOPKG_PKGNAME}_install.log"
+# else
+#     INST_LOG="${SYNOPKG_TEMP_LOGFILE}"
+# fi
+
+INST_ETC="/var/packages/${SYNOPKG_PKGNAME}/etc"
+INST_VARIABLES="${INST_ETC}/installer-variables"
+INST_VAR="${SYNOPKG_PKGDEST}/var"
+# INST_VAR="${SYNOPKG_PKGVAR}"
+
+# Optional FWPORTS file
+FWPORTS_FILE="/var/packages/${SYNOPKG_PKGNAME}/conf/${SYNOPKG_PKGNAME}.sc"
+
+# Versions lower then DSM 6 don't support an upgrade folder
+if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
+    TMP_DIR="/var/tmp/${SYNOPKG_PKGNAME}/var"
+else
+    TMP_DIR="${SYNOPKG_TEMP_UPGRADE_FOLDER}/var"
+fi
+
+# Source package specific variable and functions
+SVC_SETUP=`dirname $0`"/service-setup"
+if [ -r "${SVC_SETUP}" ]; then
+    . "${SVC_SETUP}"
+fi
+
+# Reload wizard variables stored by postinst
+if [ -r "${INST_VARIABLES}" ]; then
+    . "${INST_VARIABLES}"
+fi
+
+# Expect user to be set from package specific variables
+if [ -n "${USER}" -a -z "${USER_DESC}" ]; then
+    USER_DESC="User running $SYNOPKG_PKGNAME"
+fi
+
+# Default description if group name provided by UI
+if [ -n "${GROUP}" -a -z "${GROUP_DESC}" ]; then
+    GROUP_DESC="SynoCommunity Package Group"
+fi
+
+# Extract share volume and share name from download location if provided
+if [ -n "${SHARE_PATH}" ]; then
+    SHARE_VOLUME=$(echo "${SHARE_PATH}" | awk -F/ '{print "/"$2}')
+    SHARE_NAME=$(echo "${SHARE_PATH}" | awk -F/ '{print $3}')
+fi
+
+# Tools shortcuts
+MV="/bin/mv -f"
+RM="/bin/rm -rf"
+CP="/bin/cp -rfp"
+MKDIR="/bin/mkdir -p"
+LN="/bin/ln -nsf"
+TEE="/usr/bin/tee -a"
+
+### Functions library
+
+log_step ()
+{
+    date >> ${INST_LOG}
+    echo "===> Step $1. USER=$USER GROUP=$GROUP SHARE_PATH=${SHARE_PATH}" >> ${INST_LOG}
+}
+
+save_wizard_variables ()
+{
+    if [ -e "${INST_VARIABLES}" ]; then
+        $RM "${INST_VARIABLES}"
+    fi
+    if [ -n "${GROUP}" ]; then
+        echo "GROUP=${GROUP}" >> ${INST_VARIABLES}
+    fi
+    if [ -n "${SHARE_PATH}" ]; then
+        echo "SHARE_PATH=${SHARE_PATH}" >> ${INST_VARIABLES}
+    fi
+}
+
+# Remove user from system and from groups it is member of
+syno_remove_user ()
+{
+    RM_USER=$1
+    if [ -n "${RM_USER}" ]; then
+        # Check if user exists
+        if synouser --get "${RM_USER}" &> /dev/null; then
+            echo "Removing user ${RM_USER}" >> ${INST_LOG}
+            synouser --del "${RM_USER}" >> ${INST_LOG} 2>&1
+            synouser --rebuild all >> ${INST_LOG} 2>&1
+            # Also rebuild groups so users are removed
+            synogroup --rebuild all >> ${INST_LOG} 2>&1
+        fi
+    fi
+}
+
+# Create syno group $GROUP with parameter user as member
+syno_group_create ()
+{
+    EFF_USER=$1
+    if [ -n "${EFF_USER}" ]; then
+        echo "Creating group ${GROUP}" >> ${INST_LOG}
+        # Create syno group
+        synogroup --add "${GROUP}" "${EFF_USER}" >> ${INST_LOG} 2>&1
+        # Set description of the syno group
+        synogroup --descset "${GROUP}" "${GROUP_DESC}" >> ${INST_LOG} 2>&1
+    fi
+}
+
+# Delete syno group if empty
+syno_group_remove ()
+{
+    RM_GROUP=$1
+    if [ -n "${RM_GROUP}" ]; then
+        # Check if syno group is empty
+        if ! synogroup --get "${RM_GROUP}" | grep -q "0:\["; then
+            echo "Removing group ${RM_GROUP}" >> ${INST_LOG}
+            # Remove syno group
+            synogroup --del "${RM_GROUP}" >> ${INST_LOG} 2>&1
+            synogroup --rebuild all >> ${INST_LOG} 2>&1
+        fi
+    fi
+}
+
+# Add user to existing group
+syno_user_add_to_group ()
+{
+    ADD_USER=$1
+    ADD_GROUP=$2
+    # Check user already in group
+    if ! synogroup --get "$ADD_GROUP" | grep "^[0-9]:\[${ADD_USER}\]" &> /dev/null; then
+        # Add user, not in group yet
+        echo "Adding '${ADD_USER}' to '${ADD_GROUP}'" >> ${INST_LOG}
+        MEMBERS="$(synogroup --get $ADD_GROUP | grep '^[0-9]' | sed 's/.*\[\([^]]*\)].*/\1/' | tr '\n' ' ')"
+        # The "synogroup --member" command clears all users before adding new ones
+        # so all the users must be listed on the command line
+        synogroup --member "$ADD_GROUP" $MEMBERS "${ADD_USER}" >> ${INST_LOG} 2>&1
+    fi
+}
+
+# Sets recursive permissions for ${GROUP} on specified directory
+# Usage: set_syno_permissions "${SHARE_FOLDER}" "${GROUP}"
+set_syno_permissions ()
+{
+    DIRNAME=`realpath "${1}"`
+    GROUP="${2}"
+
+    VOLUME=$(echo "${DIRNAME}" | awk -F/ '{print "/"$2}')
+
+    # Ensure directory resides in /volumeX before setting GROUP permissions
+    if [ "`echo ${VOLUME} | cut -c2-7`" = "volume" ]; then
+        # Set read/write permissions for GROUP for folder and subfolders
+        if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:rwxpdDaARWcC-:fd--\"`" ]; then
+            # First Unix permissions, but only if it's in Linux mode
+            if [ "`synoacltool -get \"${DIRNAME}\"| grep \"Linux mode\"`" ]; then
+                # If it is linux mode (due to old package) we need to add "administrators"-group,
+                # otherwise the folder is not accessible from File Station anymore!
+                synoacltool -add "${DIRNAME}" "group:administrators:allow:rwxpdDaARWc--:fd--" >> ${INST_LOG} 2>&1
+            fi
+
+            # Then fix the Synology permissions
+            echo "Granting '${GROUP}' group permissions on ${DIRNAME}" >> ${INST_LOG}
+            synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:rwxpdDaARWcC-:fd--" >> ${INST_LOG} 2>&1
+            find "${DIRNAME}" -type d -exec synoacltool -enforce-inherit "{}" \; >> ${INST_LOG} 2>&1
+        fi
+
+        # Walk up the tree and set traverse execute permissions for GROUP up to VOLUME
+        while [ "${DIRNAME}" != "${VOLUME}" ]; do
+            if [ ! "`synoacltool -get \"${DIRNAME}\"| grep \"group:${GROUP}:allow:r.x\"`" ]; then
+                # Here we also need to make sure the admin can access data via File Station
+                if [ "`synoacltool -get \"${DIRNAME}\"| grep \"Linux mode\"`" ]; then
+                    synoacltool -add "${DIRNAME}" "group:administrators:allow:rwxpdDaARWc--:fd--" >> ${INST_LOG} 2>&1
+                fi
+                # Add the new group permissions
+                echo "Granting '${GROUP}' group basic permissions on ${DIRNAME}" >> ${INST_LOG}
+                synoacltool -add "${DIRNAME}" "group:${GROUP}:allow:r-x---a-R----:---n" >> ${INST_LOG} 2>&1
+            fi
+            DIRNAME="$(dirname "${DIRNAME}")"
+        done
+    else
+        echo "Skip granting '${GROUP}' group permissions on ${DIRNAME} as the directory does not reside in '/volumeX'. Set manually if needed." >> ${INST_LOG}
+    fi
+}
+
+# If package was moved to new group, we need to add the new package user
+# also to the old group. Only if the legacy user was in the old group.
+# Usage: syno_user_add_to_legacy_group "${NEW_USER}" "${LEGACY_USER}" "${LEGACY_GROUP}"
+syno_user_add_to_legacy_group () {
+    NEW_USER=$1
+    LEGACY_USER=$2
+    LEGACY_GROUP=$3
+
+    # Check if user in old group
+    if synogroup --get "$LEGACY_GROUP" | grep "^[0-9]:\[${LEGACY_USER}\]" &> /dev/null; then
+        # Add new user and remove old one
+        echo "Adding '${NEW_USER}' to '${LEGACY_GROUP}' for backwards compatibility" >> ${INST_LOG}
+        MEMBERS="$(synogroup --get $LEGACY_GROUP | grep '^[0-9]' | sed 's/.*\[\([^]]*\)].*/\1/' | tr '\n' ' ')"
+        MEMBERS=${MEMBERS//$LEGACY_USER}
+        # The "synogroup --member" command clears all users before adding new ones
+        # so all the users must be listed on the command line
+        synogroup --member "$LEGACY_GROUP" $MEMBERS "${NEW_USER}" >> ${INST_LOG} 2>&1
+    fi
+}
+
+
+### Generic package behaviors
+
+preinst ()
+{
+    log_step "preinst"
+    call_func "service_preinst"
+
+    # Check volume exists
+    if [ -n "${SHARE_PATH}" ]; then
+        if [ ! -d "${SHARE_VOLUME}" ]; then
+            echo "Volume ${SHARE_VOLUME} does not exist." | $TEE ${INST_LOG}
+            exit 1
+        fi
+    fi
+
+    exit 0
+}
+
+postinst ()
+{
+    log_step "postinst"
+    save_wizard_variables
+
+    if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 7 ]; then
+        # Link for backward compatibility of binaries location
+        $LN "${SYNOPKG_PKGDEST}" "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG}
+    fi
+    # Add firewall config
+    if [ -r "${FWPORTS_FILE}" ]; then
+        echo "Installing service configuration ${FWPORTS_FILE}" >> ${INST_LOG}
+        servicetool --install-configure-file --package "${FWPORTS_FILE}" >> ${INST_LOG} 2>&1
+    fi
+
+    # Service user management
+    # if [ -n "${EFF_USER}" ]; then
+    #     if [ $SYNOPKG_DSM_VERSION_MAJOR -lt 6 ]; then
+    #         # DSM 5 specific operations
+    #         # Create prefixed synouser
+    #         if ! cat /etc/passwd | grep "${EFF_USER}:x:" &> /dev/null; then
+    #             synouser --add "${EFF_USER}" "" "$USER_DESC" 0 "" 0 >> ${INST_LOG} 2>&1
+    #             # Set HOME for consistency with DSM 6, location available even if homes not enabled
+    #             BACKUP_PASSWD="/tmp/install_${SYNOPKG_PKGNAME}_passwd"
+    #             cp /etc/passwd ${BACKUP_PASSWD}
+    #             sed -i "s#/var/services/homes/${EFF_USER}#/var/packages/${SYNOPKG_PKGNAME}/target#" /etc/passwd
+    #         fi
+    #     fi
+    #     # Register service in "users" group to access any content
+    #     if [ "$ADD_USER_IN_USERS" = "yes" ]; then
+    #         syno_user_add_to_group "${EFF_USER}" "users"
+    #     fi
+    # fi
+
+    # # Only if a group is provided via UI or set by script
+    # if [ -n "$GROUP" ]; then
+    #     # Check if group already exists
+    #     if ! synogroup --get "$GROUP" &> /dev/null; then
+    #         # Group does not exist yet: create with user as member
+    #         syno_group_create "${EFF_USER}"
+    #     fi
+    #     if synogroup --get "$GROUP" &> /dev/null; then
+    #         syno_user_add_to_group "${EFF_USER}" "${GROUP}"
+    #     fi
+    #     # Not sure but invoked with hope DSM is updated
+    #     synogroup --rebuild all
+    # fi
+
+    # Share management
+    if [ -n "${SHARE_PATH}" ]; then
+        echo "Configuring ${SHARE_PATH}" >> ${INST_LOG}
+        # Create share if does not exist
+        #  !"#$%&’()*+,/:;<=>?@[]nˆ`{} |
+        if ! synoshare --get "${SHARE_NAME}" &> /dev/null ; then
+            synoshare --add "${SHARE_NAME}" "${SHARE_DESC}" "${SHARE_PATH}" "" "rw" "" 1 0 >> ${INST_LOG} 2>&1
+        fi
+
+        # Add user permission if no GROUP is set in UI
+        # GROUP permission will be added in set_syno_permissions
+        if [ ! -n "$GROUP" ] && [ -n "${EFF_USER}" ]; then
+            synoshare --setuser "${SHARE_NAME}" RW + "${EFF_USER}" >> ${INST_LOG} 2>&1
+        fi
+        synoshare --build >> ${INST_LOG} 2>&1
+
+        $MKDIR "${SHARE_PATH}"
+
+        # Permissions for folder, up to volume
+        if [ -n "$GROUP" ]; then
+            set_syno_permissions "${SHARE_PATH}" "${GROUP}"
+        fi
+    fi
+
+    $MKDIR "${INST_VAR}" >> ${INST_LOG} 2>&1
+
+    call_func "service_postinst"
+    call_func "service_create_links"
+
+    $CP "${INST_LOG}" "${INST_VAR}" >> ${INST_LOG} 2>&1
+    if [ -n "${LOG_FILE}" ]; then
+        echo "Installation log: ${INST_VAR}/${SYNOPKG_PKGNAME}_install.log" >> ${LOG_FILE}
+    fi
+    exit 0
+}
+
+preuninst ()
+{
+    log_step "preuninst"
+
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        # Remove firewall config
+        if [ -r "${FWPORTS_FILE}" ]; then
+            echo "Removing service configuration ${SYNOPKG_PKGNAME}.sc" >> ${INST_LOG}
+            servicetool --remove-configure-file --package "${SYNOPKG_PKGNAME}.sc" >> ${INST_LOG} 2>&1
+        fi
+    fi
+
+    call_func "service_preuninst"
+    exit 0
+}
+
+postuninst ()
+{
+    log_step "postuninst"
+
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        # Remove link
+        $RM "/usr/local/${SYNOPKG_PKGNAME}" >> ${INST_LOG} 2>&1
+
+        # Remove syno group if empty
+        syno_group_remove "${GROUP}"
+
+        # Remove user
+        syno_remove_user "${EFF_USER}"
+    fi
+
+    call_func "service_postuninst"
+    call_func "service_remove_links"
+
+    if [ "${SYNOPKG_PKG_STATUS}" == "UNINSTALL" ]; then
+        $RM "${INST_VARIABLES}" >> ${INST_LOG} 2>&1
+    fi
+    exit 0
+}
+
+preupgrade ()
+{
+    log_step "preupgrade"
+    call_func "service_preupgrade"
+
+    # Save some stuff
+    $RM "$TMP_DIR" >> ${INST_LOG} 2>&1
+    $MKDIR "$TMP_DIR" >> ${INST_LOG} 2>&1
+
+    call_func "service_save"
+
+    # Beware of /. outside the quotes
+    # Needed to copy all files including hidden ones
+    $CP "${INST_VAR}"/. "$TMP_DIR" >> ${INST_LOG} 2>&1
+    exit 0
+}
+
+postupgrade ()
+{
+    log_step "postupgrade"
+
+    call_func "service_restore"
+
+    # Restore some stuff, has to be cp otherwise fails on directories
+    $CP "${TMP_DIR}"/. "${INST_VAR}" >> ${INST_LOG} 2>&1
+
+    $RM "$TMP_DIR" >> ${INST_LOG} 2>&1
+
+    call_func "service_postupgrade"
+
+    # Make sure we also have the logging for this step
+    $CP "${INST_LOG}" "${INST_VAR}"
+    exit 0
+}

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -3,6 +3,7 @@
 # DSM 5 -> 7 upgrade path:
 # Not supported
 # DSM 6 -> 7 upgrade path:
+# files are migrated from ${SYNOPKG_PKGDEST}/var to ${SYNOPKG_PKGVAR}
 # Not supported (yet)
 
 
@@ -172,6 +173,12 @@ postuninst ()
 preupgrade ()
 {
     log_step "preupgrade"
+
+    # dsm6 -> dsm7
+    # Migrate data to permanent storage
+
+    $CP -RT ${SYNOPKG_PKGDEST}/var/. ${SYNOPKG_PKGVAR}
+
     call_func "service_preupgrade"
 
     # Save some stuff

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -85,24 +85,28 @@ save_wizard_variables ()
 # Remove user from system and from groups it is member of
 syno_remove_user ()
 {
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_remove_user() function no longer works."
     return 0
 }
 
 # Create syno group $GROUP with parameter user as member
 syno_group_create ()
 {
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_group_create() function no longer works."
     return 0
 }
 
 # Delete syno group if empty
 syno_group_remove ()
 {
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_group_remove() function no longer works."
     return 0
 }
 
 # Add user to existing group
 syno_user_add_to_group ()
 {
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_user_add_to_group() function no longer works."
     return 0
 }
 
@@ -110,6 +114,7 @@ syno_user_add_to_group ()
 # Usage: set_syno_permissions "${SHARE_FOLDER}" "${GROUP}"
 set_syno_permissions ()
 {
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: set_syno_permissions() function no longer works."
     return 0
 }
 
@@ -117,6 +122,7 @@ set_syno_permissions ()
 # also to the old group. Only if the legacy user was in the old group.
 # Usage: syno_user_add_to_legacy_group "${NEW_USER}" "${LEGACY_USER}" "${LEGACY_GROUP}"
 syno_user_add_to_legacy_group () {
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_user_add_to_legacy_group() function no longer works."
     return 0
 }
 

--- a/mk/spksrc.service.installer.dsm7
+++ b/mk/spksrc.service.installer.dsm7
@@ -85,28 +85,28 @@ save_wizard_variables ()
 # Remove user from system and from groups it is member of
 syno_remove_user ()
 {
-    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_remove_user() function no longer works."
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_remove_user() is no longer supported."
     return 0
 }
 
 # Create syno group $GROUP with parameter user as member
 syno_group_create ()
 {
-    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_group_create() function no longer works."
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_group_create() is no longer supported."
     return 0
 }
 
 # Delete syno group if empty
 syno_group_remove ()
 {
-    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_group_remove() function no longer works."
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_group_remove() is no longer supported."
     return 0
 }
 
 # Add user to existing group
 syno_user_add_to_group ()
 {
-    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_user_add_to_group() function no longer works."
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_user_add_to_group() is no longer supported."
     return 0
 }
 
@@ -114,7 +114,7 @@ syno_user_add_to_group ()
 # Usage: set_syno_permissions "${SHARE_FOLDER}" "${GROUP}"
 set_syno_permissions ()
 {
-    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: set_syno_permissions() function no longer works."
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: set_syno_permissions() is no longer supported."
     return 0
 }
 
@@ -122,7 +122,7 @@ set_syno_permissions ()
 # also to the old group. Only if the legacy user was in the old group.
 # Usage: syno_user_add_to_legacy_group "${NEW_USER}" "${LEGACY_USER}" "${LEGACY_GROUP}"
 syno_user_add_to_legacy_group () {
-    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_user_add_to_legacy_group() function no longer works."
+    echo "This package has not been updated to DSM7 yet. Please open a new issue, mentioning this text: syno_user_add_to_legacy_group() is no longer supported."
     return 0
 }
 

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -42,7 +42,8 @@ endif
 .PHONY: service_target service_msg_target
 .PHONY: $(PRE_SERVICE_TARGET) $(SERVICE_TARGET) $(POST_SERVICE_TARGET)
 .PHONY: $(DSM_SCRIPTS_DIR)/service-setup $(DSM_SCRIPTS_DIR)/start-stop-status
-.PHONY: $(DSM_CONF_DIR)/privilege $(DSM_CONF_DIR)/$(SPK_NAME).sc $(STAGING_DIR)/$(DSM_UI_DIR)/config
+.PHONY: $(DSM_CONF_DIR)/privilege $(DSM_CONF_DIR)/resource
+.PHONY: $(DSM_CONF_DIR)/$(SPK_NAME).sc $(STAGING_DIR)/$(DSM_UI_DIR)/config
 
 service_msg_target:
 	@$(MSG) "Generating service scripts for $(NAME)"
@@ -59,9 +60,11 @@ endif
 # Recommend explicit STARTABLE=no
 ifeq ($(strip $(SSS_SCRIPT)),)
 ifeq ($(strip $(SERVICE_COMMAND)),)
+ifeq ($(strip $(SPK_COMMANDS)),)
 ifeq ($(strip $(SERVICE_EXE)),)
 ifeq ($(strip $(STARTABLE)),)
-$(error Set STARTABLE=no or provide either SERVICE_COMMAND or specific SSS_SCRIPT)
+$(error Set STARTABLE=no or provide either SERVICE_COMMAND, SPK_COMMANDS or specific SSS_SCRIPT)
+endif
 endif
 endif
 endif
@@ -119,12 +122,25 @@ endif
 ifneq ($(strip $(SERVICE_SETUP)),)
 	@cat $(CURDIR)/$(SERVICE_SETUP) >> $@
 endif
+
+ifneq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
 ifneq ($(strip $(SPK_COMMANDS) $(SPK_LINKS)),)
 	@echo "# List of commands to create links for" >> $@
 	@echo "SPK_COMMANDS=\"${SPK_COMMANDS}\"" >> $@
 	@echo "SPK_LINKS=\"${SPK_LINKS}\"" >> $@
 	@cat $(SPKSRC_MK)spksrc.service.create_links >> $@
 endif
+else
+SPK_COMMANDS_IN_JSON = $(shell printf '"%s",' ${SPK_COMMANDS} | sed 's/.$$//')
+$(DSM_CONF_DIR)/resource: $(SPKSRC_MK)spksrc.service.resource-linker
+	$(create_target_dir)
+	@sed 's|"BINARIES"|${SPK_COMMANDS_IN_JSON}|' $< > $@
+SERVICE_FILES += $(DSM_CONF_DIR)/resource
+# STARTABLE needs to be yes, the resource linking and unlinking works on start and stop
+# see spsrc.spk.mk
+endif
+
+
 DSM_SCRIPTS_ += service-setup
 SERVICE_FILES += $(DSM_SCRIPTS_DIR)/service-setup
 
@@ -155,19 +171,24 @@ endif
 
 
 # Generate privilege file for service user (prefixed to avoid collision with busybox account)
-ifneq ($(strip $(SPK_USER)),)
-ifeq ($(strip $(SERVICE_EXE)),)
+ifeq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
 $(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege
+else ifeq ($(strip $(SERVICE_EXE)),)
+$(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege-installasroot
 else
 $(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege-startasroot
 endif
 	$(create_target_dir)
+ifneq ($(strip $(SPK_USER)),)
 	@sed 's|USER|sc-$(SPK_USER)|' $< > $@
+else
+	@sed 's|USER|sc-$(SPK_NAME)|' $< > $@
+# 	@sed '/.*USER.*/d' $< > $@
+endif
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)
 SPK_CONTENT += conf
 endif
 SERVICE_FILES += $(DSM_CONF_DIR)/privilege
-endif
 
 
 # Generate service configuration for admin port

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -184,10 +184,10 @@ else
 $(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege-startasroot
 endif
 	$(create_target_dir)
-ifneq ($(strip $(SPK_USER)),)
-	@sed 's|USER|sc-$(SPK_USER)|' $< > $@
+ifneq ($(strip $(EFF_USER)),)
+	@sed 's|USER|$(EFF_USER)|' $< > $@
 else
-	@sed 's|USER|sc-$(SPK_NAME)|' $< > $@
+	@sed 's|USER|$(SPK_NAME)|' $< > $@
 # 	@sed '/.*USER.*/d' $< > $@
 endif
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -148,8 +148,13 @@ SERVICE_FILES += $(DSM_SCRIPTS_DIR)/service-setup
 # Control use of generic installer
 ifeq ($(strip $(INSTALLER_SCRIPT)),)
 DSM_SCRIPTS_ += installer
+ifeq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
+$(DSM_SCRIPTS_DIR)/installer: $(SPKSRC_MK)spksrc.service.installer.dsm7
+	@$(dsm_script_copy)
+else
 $(DSM_SCRIPTS_DIR)/installer: $(SPKSRC_MK)spksrc.service.installer
 	@$(dsm_script_copy)
+endif
 endif
 
 # Control use of generic start-stop-status scripts

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -98,10 +98,17 @@ ifneq ($(strip $(SERVICE_PORT)),)
 	@echo 'SERVICE_PORT="$(SERVICE_PORT)"' >> $@
 endif
 ifneq ($(STARTABLE),no)
+ifneq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
 	@echo "# start-stop-status script redirect stdout/stderr to LOG_FILE" >> $@
 	@echo 'LOG_FILE="$${SYNOPKG_PKGDEST}/var/$${SYNOPKG_PKGNAME}.log"' >> $@
 	@echo "# Service command has to deliver its pid into PID_FILE" >> $@
 	@echo 'PID_FILE="$${SYNOPKG_PKGDEST}/var/$${SYNOPKG_PKGNAME}.pid"' >> $@
+else
+	@echo "# start-stop-status script redirect stdout/stderr to LOG_FILE" >> $@
+	@echo 'LOG_FILE="$${SYNOPKG_PKGVAR}/$${SYNOPKG_PKGNAME}.log"' >> $@
+	@echo "# Service command has to deliver its pid into PID_FILE" >> $@
+	@echo 'PID_FILE="$${SYNOPKG_PKGVAR}/$${SYNOPKG_PKGNAME}.pid"' >> $@
+endif
 endif
 ifneq ($(strip $(SERVICE_COMMAND)),)
 ifneq ($(strip $(SERVICE_SHELL)),)

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -184,12 +184,7 @@ else
 $(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege-startasroot
 endif
 	$(create_target_dir)
-ifneq ($(strip $(EFF_USER)),)
-	@sed 's|USER|$(EFF_USER)|' $< > $@
-else
-	@sed 's|USER|$(SPK_NAME)|' $< > $@
-# 	@sed '/.*USER.*/d' $< > $@
-endif
+	@sed 's|USER|sc-$(SPK_USER)|' $< > $@
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)
 SPK_CONTENT += conf
 endif

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -60,12 +60,6 @@ ifeq ($(strip $(SPK_USER)),)
 SPK_USER = $(SPK_NAME)
 endif
 
-# Temporary Shim
-ifeq ($(strip $(GROUP)),)
-GROUP = $(shell grep '^GROUP=' src/service-setup.sh 2>/dev/null | awk -F = '{print $$2}' | sed 's/"//g')
-endif
-# end shim
-
 # Recommend explicit STARTABLE=no
 ifeq ($(strip $(SSS_SCRIPT)),)
 ifeq ($(strip $(SERVICE_COMMAND)),)
@@ -208,8 +202,12 @@ endif
 #- 1<> $@
 #+ | sponge $@
 	jq '.username = "sc-$(SPK_USER)"' $@ 1<>$@
+	jq '."groupname" = "sc-$(SPK_USER)"' $@ 1<>$@
 ifeq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
 ifneq ($(strip $(GROUP)),)
+	# Creates group but is different from the groups the user can create, they are invisible in the UI an are only usefull to access another packages permissions (ffmpeg comes to mind)
+	# For DSM7 I recommend setting permissions for individual packages (System Internal User)
+	# or use the shared folder resource worker to add permissions, ask user from wizard
 	jq --arg packagename $(GROUP) '."join-pkg-groupnames" += [{$$packagename}]' $@ 1<>$@
 endif
 endif

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -3,7 +3,7 @@
 #   scripts/installer
 #   scripts/start-stop-status
 #   scripts/service-setup
-#   conf/privilege        if SERVICE_USER
+#   conf/privilege        if SERVICE_USER or DSM7
 #   conf/SPK_NAME.sc      if SERVICE_PORT
 #   app/config            if DSM_UI_DIR
 #
@@ -59,6 +59,12 @@ endif
 ifeq ($(strip $(SPK_USER)),)
 SPK_USER = $(SPK_NAME)
 endif
+
+# Temporary Shim
+ifeq ($(strip $(GROUP)),)
+GROUP = $(shell grep '^GROUP=' src/service-setup.sh 2>/dev/null | awk -F = '{print $$2}' | sed 's/"//g')
+endif
+# end shim
 
 # Recommend explicit STARTABLE=no
 ifeq ($(strip $(SSS_SCRIPT)),)
@@ -202,6 +208,11 @@ endif
 #- 1<> $@
 #+ | sponge $@
 	jq '.username = "sc-$(SPK_USER)"' $@ 1<>$@
+ifeq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
+ifneq ($(strip $(GROUP)),)
+	jq --arg packagename $(GROUP) '."join-pkg-groupnames" += [{$$packagename}]' $@ 1<>$@
+endif
+endif
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)
 SPK_CONTENT += conf
 endif

--- a/mk/spksrc.service.mk
+++ b/mk/spksrc.service.mk
@@ -56,6 +56,9 @@ SPK_USER = $(SPK_NAME)
 else
 SPK_USER = $(SERVICE_USER)
 endif
+ifeq ($(strip $(SPK_USER)),)
+SPK_USER = $(SPK_NAME)
+endif
 
 # Recommend explicit STARTABLE=no
 ifeq ($(strip $(SSS_SCRIPT)),)
@@ -138,10 +141,11 @@ ifneq ($(strip $(SPK_COMMANDS) $(SPK_LINKS)),)
 	@cat $(SPKSRC_MK)spksrc.service.create_links >> $@
 endif
 else
-SPK_COMMANDS_IN_JSON = $(shell printf '"%s",' ${SPK_COMMANDS} | sed 's/.$$//')
-$(DSM_CONF_DIR)/resource: $(SPKSRC_MK)spksrc.service.resource-linker
+
+SPK_COMMANDS_IN_JSON = $(shell echo ${SPK_COMMANDS} | jq -Rc '. | split(" ")')
+$(DSM_CONF_DIR)/resource:
 	$(create_target_dir)
-	@sed 's|"BINARIES"|${SPK_COMMANDS_IN_JSON}|' $< > $@
+	@jq -n '."usr-local-linker" = {"bin": $$binaries}' --argjson binaries '$(SPK_COMMANDS_IN_JSON)' > $@
 SERVICE_FILES += $(DSM_CONF_DIR)/resource
 # STARTABLE needs to be yes, the resource linking and unlinking works on start and stop
 # see spsrc.spk.mk
@@ -184,14 +188,20 @@ endif
 
 # Generate privilege file for service user (prefixed to avoid collision with busybox account)
 ifeq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
-$(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege
-else ifeq ($(strip $(SERVICE_EXE)),)
+$(DSM_CONF_DIR)/privilege:
+	$(create_target_dir)
+	jq -n '.defaults = {"run-as": "package"}' > $@
+else
+ifeq ($(strip $(SERVICE_EXE)),)
 $(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege-installasroot
 else
 $(DSM_CONF_DIR)/privilege: $(SPKSRC_MK)spksrc.service.privilege-startasroot
 endif
-	$(create_target_dir)
-	@sed 's|USER|sc-$(SPK_USER)|' $< > $@
+endif
+# TODO add moreutils package, use sponge to prevent overriding file with 0 content
+#- 1<> $@
+#+ | sponge $@
+	jq '.username = "sc-$(SPK_USER)"' $@ 1<>$@
 ifneq ($(findstring conf,$(SPK_CONTENT)),conf)
 SPK_CONTENT += conf
 endif

--- a/mk/spksrc.service.privilege
+++ b/mk/spksrc.service.privilege
@@ -1,6 +1,0 @@
-{
-	"defaults":{
-		"run-as": "package"
-	},
-	"username": "USER"
-}

--- a/mk/spksrc.service.privilege
+++ b/mk/spksrc.service.privilege
@@ -2,24 +2,5 @@
 	"defaults":{
 		"run-as": "package"
 	},
-	"username": "USER",
-	"ctrl-script": [{
-		"action": "preinst",
-		"run-as": "root"
-	}, {
-		"action": "postinst",
-		"run-as": "root"
-	}, {
-		"action": "preuninst",
-		"run-as": "root"
-	}, {
-		"action": "postuninst",
-		"run-as": "root"
-	}, {
-		"action": "preupgrade",
-		"run-as": "root"
-	}, {
-		"action": "postupgrade",
-		"run-as": "root"
-	}]
+	"username": "USER"
 }

--- a/mk/spksrc.service.privilege-installasroot
+++ b/mk/spksrc.service.privilege-installasroot
@@ -1,0 +1,25 @@
+{
+	"defaults":{
+        "run-as": "package"
+    },
+    "username": "USER",
+    "ctrl-script": [{
+        "action": "preinst",
+        "run-as": "root"
+    }, {
+        "action": "postinst",
+        "run-as": "root"
+    }, {
+        "action": "preuninst",
+        "run-as": "root"
+    }, {
+        "action": "postuninst",
+        "run-as": "root"
+    }, {
+        "action": "preupgrade",
+        "run-as": "root"
+    }, {
+        "action": "postupgrade",
+        "run-as": "root"
+    }]
+}

--- a/mk/spksrc.service.resource-linker
+++ b/mk/spksrc.service.resource-linker
@@ -1,0 +1,5 @@
+{
+    "usr-local-linker": {
+        "bin": ["BINARIES"]
+    }
+}

--- a/mk/spksrc.service.resource-linker
+++ b/mk/spksrc.service.resource-linker
@@ -1,5 +1,0 @@
-{
-    "usr-local-linker": {
-        "bin": ["BINARIES"]
-    }
-}

--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -35,11 +35,17 @@ start_daemon ()
             else
                 SVC_CD="cd ${SVC_CWD}; "
             fi
-            if [ -z "${SVC_BACKGROUND}" ]; then
-                ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1
+            if [ -n "${SYNOPKG_DSM_VERSION_MAJOR}" ] && [ "$SYNOPKG_DSM_VERSION_MAJOR" -gt 7 ]; then
+                SU=""
             else
-                ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1 &
+                SU="su ${EFF_USER} -s"
             fi
+            if [ -z "${SVC_BACKGROUND}" ]; then
+                $SU ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1
+            else
+                $SU ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1 &
+            fi
+
         else
             # DSM 6 user is set by conf/privilege
             if [ -n "${SVC_CWD}" ]; then

--- a/mk/spksrc.service.start-stop-status
+++ b/mk/spksrc.service.start-stop-status
@@ -36,9 +36,9 @@ start_daemon ()
                 SVC_CD="cd ${SVC_CWD}; "
             fi
             if [ -z "${SVC_BACKGROUND}" ]; then
-                su ${EFF_USER} -s ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1
+                ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1
             else
-                su ${EFF_USER} -s ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1 &
+                ${SERVICE_SHELL} -c "${SVC_CD}${SERVICE_COMMAND}" >> ${OUT} 2>&1 &
             fi
         else
             # DSM 6 user is set by conf/privilege

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -125,9 +125,9 @@ endif
 ifneq ($(strip $(HELPURL)),)
 	@echo helpurl=\"$(HELPURL)\" >> $@
 else
-  ifneq ($(strip $(HOMEPAGE)),)
+ifneq ($(strip $(HOMEPAGE)),)
 	@echo helpurl=\"$(HOMEPAGE)\" >> $@
-  endif
+endif
 endif
 ifneq ($(strip $(SUPPORTURL)),)
 	@echo support_url=\"$(SUPPORTURL)\" >> $@
@@ -141,15 +141,28 @@ endif
 ifneq ($(strip $(INSTUNINST_RESTART_SERVICES)),)
 	@echo instuninst_restart_services=\"$(INSTUNINST_RESTART_SERVICES)\" >> $@
 endif
-ifneq ($(strip $(RELOAD_UI)),)
+ifeq ($(RELOAD_UI),yes)
 	@echo reloadui=\"$(RELOAD_UI)\" >> $@
 endif
+
+ifneq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
+# old behaviour
 ifeq ($(STARTABLE),no)
 ifeq ($(shell expr "$(TC_OS_MIN_VER)" \<= 6.1),1)
 	@echo startable=\"$(STARTABLE)\" >> $@
 endif
 	@echo ctl_stop=\"$(STARTABLE)\" >> $@
 endif
+else
+# since 7.0 use Synology resource acquisition
+ifeq ($(STARTABLE),no)
+ifeq ($(strip $(SPK_COMMANDS)),)
+# STARTABLE needs to be yes, Resource linking and unlinking works on start and stop
+	@echo ctl_stop=\"$(STARTABLE)\" >> $@
+endif
+endif
+endif
+
 	@echo displayname=\"$(DISPLAY_NAME)\" >> $@
 ifneq ($(strip $(DSM_UI_DIR)),)
 	@echo dsmuidir=\"$(DSM_UI_DIR)\" >> $@

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -169,8 +169,12 @@ ifneq ($(strip $(DSM_UI_DIR)),)
 endif
 ifneq ($(strip $(DSM_APP_NAME)),)
 	@echo dsmappname=\"$(DSM_APP_NAME)\" >> $@
+	@echo dsmapppage=\"$(DSM_APP_NAME)\" >> $@
+	@echo dsmapplaunchname=\"$(DSM_APP_NAME)\" >> $@
 else
 	@echo dsmappname=\"com.synocommunity.$(SPK_NAME)\" >> $@
+	@echo dsmapppage=\"com.synocommunity.$(SPK_NAME)\" >> $@
+	@echo dsmapplaunchname=\"com.synocommunity.$(SPK_NAME)\" >> $@
 endif
 ifneq ($(strip $(ADMIN_PROTOCOL)),)
 	@echo adminprotocol=\"$(ADMIN_PROTOCOL)\" >> $@

--- a/mk/spksrc.spk.mk
+++ b/mk/spksrc.spk.mk
@@ -277,10 +277,14 @@ icons:
 ifneq ($(strip $(SPK_ICON)),)
 	$(create_target_dir)
 	@$(MSG) "Creating PACKAGE_ICON.PNG for $(SPK_NAME)"
+ifneq ($(shell expr "$(TCVERSION)" \>= 7.0),1)
 	(convert $(SPK_ICON) -thumbnail 72x72 -strip - > $(WORK_DIR)/PACKAGE_ICON.PNG)
+else
+	(convert $(SPK_ICON) -thumbnail 64x64 -strip - > $(WORK_DIR)/PACKAGE_ICON.PNG)
+endif  
 	@$(MSG) "Creating PACKAGE_ICON_256.PNG for $(SPK_NAME)"
 	(convert $(SPK_ICON) -thumbnail 256x256 -strip - > $(WORK_DIR)/PACKAGE_ICON_256.PNG)
-	$(eval SPK_CONTENT +=  PACKAGE_ICON.PNG PACKAGE_ICON_256.PNG)
+	$(eval SPK_CONTENT += PACKAGE_ICON.PNG PACKAGE_ICON_256.PNG)
 endif
 
 .PHONY: info-checksum

--- a/mk/spksrc.tc-vers.mk
+++ b/mk/spksrc.tc-vers.mk
@@ -57,3 +57,7 @@ endif
 ifeq ($(TC_VERS),6.2.3)
 TC_BUILD = 25423
 endif
+
+ifeq ($(TC_VERS),7.0)
+TC_BUILD = 4000
+endif

--- a/spk/radarr/src/service-setup.sh
+++ b/spk/radarr/src/service-setup.sh
@@ -7,8 +7,8 @@ RADARR="${SYNOPKG_PKGDEST}/share/Radarr/Radarr.exe"
 SPK_RADARR="${SYNOPKG_PKGINST_TEMP_DIR}/share/Radarr/Radarr.exe"
 
 # Radarr uses custom Config and PID directories
-HOME_DIR="${SYNOPKG_PKGDEST}/var"
-CONFIG_DIR="${SYNOPKG_PKGDEST}/var/.config"
+HOME_DIR="${SYNOPKG_PKGVAR}/"
+CONFIG_DIR="${SYNOPKG_PKGVAR}/.config"
 PID_FILE="${CONFIG_DIR}/Radarr/radarr.pid"
 
 # Some have it stored in the root of package

--- a/toolchains/syno-x64-7.0/Makefile
+++ b/toolchains/syno-x64-7.0/Makefile
@@ -1,0 +1,14 @@
+TC_NAME = syno-x64
+
+TC_ARCH = apollolake avoton braswell broadwell broadwellnk bromolow cedarview denverton dockerx64 geminilake grantley purley kvmx64 x86 x86_64
+TC_VERS = 7.0
+TC_KERNEL = 4.4.180+
+
+TC_DIST = apollolake-gcc730_glibc226_x86_64-GPL
+TC_DIST_SITE_PATH = Intel%20x86%20Linux%204.4.180%20%28Apollolake%29
+TC_DIST_SITE_URL = https://sourceforge.net/projects/dsgpl/files/Tool%20Chain/DSM%207.0%20preview%20Tool%20Chains/
+
+TC_TARGET = x86_64-pc-linux-gnu
+TC_SYSROOT = $(TC_TARGET)/sys-root
+
+include ../../mk/spksrc.tc.mk

--- a/toolchains/syno-x64-7.0/digests
+++ b/toolchains/syno-x64-7.0/digests
@@ -1,0 +1,3 @@
+apollolake-gcc730_glibc226_x86_64-GPL.txz SHA1 3d6a03823ef3465881354d1e68552a9546f9b6c8
+apollolake-gcc730_glibc226_x86_64-GPL.txz SHA256 40d97588d637294afc5b8377482b1ea982bd0acfe87962fbdc714cc350e35502
+apollolake-gcc730_glibc226_x86_64-GPL.txz MD5 d3e7cb99168a2ed98d5a6c1d5f49d8fc


### PR DESCRIPTION
_Motivation:_  As of the documentation this value should be the user. 
https://global.download.synology.com/download/Document/Software/DeveloperGuide/Firmware/DSM/All/enu/Synology_DiskStation_Administration_CLI_Guide.pdf (page 8)

`synoshare {--add} sharename share_desc share_path user_list_na user_list_rw user_list_ro share_browsable
adv_privilege`

